### PR TITLE
Bugfix/readonly slug for product and category

### DIFF
--- a/category/admin.py
+++ b/category/admin.py
@@ -4,5 +4,6 @@ from .models import Category
 
 class CategoryAdmin(admin.ModelAdmin):
   list_display = ('name', 'slug')
+  readonly_fields = ('slug',)
 
 admin.site.register(Category, CategoryAdmin)

--- a/category/models.py
+++ b/category/models.py
@@ -1,16 +1,20 @@
 
 from django.db import models
 from image_optimizer.fields import OptimizedImageField
+from django.utils.text import slugify
 
 class Category(models.Model):
   name = models.CharField(max_length=32)
-  #icon = models.FileField(upload_to='icon-category/')
   image = OptimizedImageField( 
     upload_to='icon-category/',
     optimized_image_output_size=(400, 300),
     optimized_image_resize_method="thumbnail"
   )
-  slug = models.CharField(max_length=32)
+  slug = models.SlugField(max_length=100, unique=True, editable=False)
 
   def __str__(self):
         return self.name
+
+  def save(self, *args, **kwargs):
+        self.slug = slugify(self.name)
+        super(Category, self).save(*args, **kwargs)

--- a/product/admin.py
+++ b/product/admin.py
@@ -6,7 +6,7 @@ from .models import Product
 
 class ProductAdmin(admin.ModelAdmin):
     list_display = ('name', 'slug', 'qty', 'pricePerQty', 'stockAvailable', 'isStockAvailable', 'image')
-    readonly_fields = ('isStockAvailable', )
+    readonly_fields = ('isStockAvailable', 'slug')
     resource_class = ProductResource
 
     def save_model(self, request, obj, form, change):

--- a/product/models.py
+++ b/product/models.py
@@ -1,17 +1,17 @@
 from django.db import models
 from category.models import Category
 from image_optimizer.fields import OptimizedImageField
+from django.utils.text import slugify
 
 class Product(models.Model):
     name =  models.CharField(max_length=32)
     description = models.CharField(max_length=255)
-    #image = models.FileField(upload_to='product/')
     image = OptimizedImageField(
         upload_to='product/',
         optimized_image_output_size=(400, 300),
         optimized_image_resize_method="thumbnail"
     )
-    slug = models.CharField(max_length=32)
+    slug = models.SlugField(max_length=100, unique=True, editable=False)
     qty = models.CharField(max_length=32)
     pricePerQty = models.PositiveIntegerField()
     stockAvailable = models.PositiveIntegerField()
@@ -20,4 +20,8 @@ class Product(models.Model):
 
     def __str__(self):
         return self.name
+
+    def save(self, *args, **kwargs):
+        self.slug = slugify(self.name)
+        super(Product, self).save(*args, **kwargs)
 


### PR DESCRIPTION
## Issue / Task

<!-- Related Github issue to this PR, you can use `resolve #prnumber` to automatically resolve issue on merge (https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).-->

membuat seluruh model yang memerlukan slug menjadi read-only dan dibuat secara otomatis menggunakan field name dari model tersebut

## Summary

<!-- A brief description about the changes proposed in the pull request.-->

slug category dan product sudah bisa dibuat secara otomatis sehingga admin tidak perlu mengisi secara manual

## Test Plan

<!-- 
A test plan is a repeatable list of steps which document what you have done to verify the behavior of a change.
(from https://secure.phabricator.com/book/phabricator/article/differential_test_plans/ You can find more useful information about test plan there)
-->
### slug product
![image](https://user-images.githubusercontent.com/92345334/200850824-686e7823-0379-4142-a47b-841fae18da8f.png)
![image](https://user-images.githubusercontent.com/92345334/200851486-81d22a8b-a9b2-40a1-a929-ceb858769e76.png)

### slug category
![image](https://user-images.githubusercontent.com/92345334/200851626-96f0e781-75d2-4a7d-96b6-b0cf61fe52da.png)
![image](https://user-images.githubusercontent.com/92345334/200852034-0693a48b-bc4f-4cb8-9ede-2c72e6c73c64.png)

